### PR TITLE
update conda env

### DIFF
--- a/envs/re.yml
+++ b/envs/re.yml
@@ -18,10 +18,12 @@ dependencies:
   - fastqc=0.12.1=hdfd78af_0
   - iced=0.5.10=py39hd5189a5_2
   - macs2=2.2.7.1=py39hbf8eff0_5
+  - matplotlib=3.7.1=py39hf3d152e_0
   - multiqc=1.14=pyhdfd78af_0
   - ncurses=6.4=hcb278e6_0
   - openssl=1.1.1s=h7f8727e_0
   - picard=3.0.0=hdfd78af_1
+  - protobuf=3.20.3=py39h227be39_1
   - pybedtools=0.9.1=py39hd65a603_0
   - pybigwig=0.3.18=py39h792ddb7_2
   - python=3.9.10=h85951f9_2_cpython


### PR DESCRIPTION
Creating a conda environment with the current re.yml  was leading to the following errors 

*  AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap'  in deeptools
*  protobuf error when in lanceotron  (which is used in bigwig mode to call peaks)

Therefore changed yml file:-

- pinned matplotlib to 3.7.1
- pinned protobuf to 3.20.3